### PR TITLE
Fixed git clone url

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This is a PowerApps custom control project template leveraging node.js.  Custom 
 
 
 ## GIT Cheatsheet
-1. `git clone https://github.com/Microsoft/PowerApps-Custom-Control-Project-Template.git` - to load code from repository
+1. `git clone https://github.com/nicknow/PowerApps-Custom-Control-Project-Template.git` - to load code from repository
 1. `git checkout -b NewBranch` - to create a new branch NewBranch
 1. `git add .` - to stage changes 
 1. `git commit -m firstCommit` - to commit changes


### PR DESCRIPTION
Hello,
the current git clone url in the git cheatsheet points to a microsoft repository which is non existent. I rewrote the url to this repository.
Best regards,
Betim Beja.